### PR TITLE
feat(java): change minimum support JDK version from 11 to 17

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [11, 17, 21, 24]
+        java: [17, 21, 25]
     name: Java ${{ matrix.java }}
     steps:
       - name: Set REPOSITORY
@@ -84,7 +84,7 @@ jobs:
           # shellcheck disable=SC2086 # [Double quote to prevent globbing and word splitting]: splitting is desired for MAVEN_CLI_OPTS
           ./mvnw ${MAVEN_CLI_OPTS} -DdependencyCheck.skip=true -Dgpg.skip=true verify
       - name: Upload artifacts
-        if: ${{ matrix.java == 11 }}
+        if: ${{ matrix.java == 17 }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ env.REPOSITORY }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -93,12 +93,6 @@ maven-check-versions:
     MAVEN_CLI_EXTRA_OPTS: "-DprocessDependencyManagementTransitive=false -Dmaven.version.ignore=(?i).+-(alpha|beta).+,(?i).+-m\\d+,(?i).+-rc\\d+"
   timeout: 10 minutes
 
-maven:jdk11:
-  stage: build
-  image: maven:3-openjdk-11-slim
-  script:
-    - "./mvnw $MAVEN_CLI_OPTS -DdependencyCheck.NVDApiKey=${NVD_API_KEY} verify"
-
 maven:jdk17:
   stage: build
   image: maven:3-openjdk-17-slim
@@ -111,8 +105,8 @@ maven:jdk21:
   script:
     - "./mvnw $MAVEN_CLI_OPTS -DdependencyCheck.NVDApiKey=${NVD_API_KEY} verify"
 
-maven:jdk24:
+maven:jdk25:
   stage: build
-  image: maven:3-eclipse-temurin-24-alpine
+  image: maven:3-eclipse-temurin-25-alpine
   script:
     - "./mvnw $MAVEN_CLI_OPTS -DdependencyCheck.skip=true verify"

--- a/README.md
+++ b/README.md
@@ -15,9 +15,11 @@ A small library of (hopefully) useful Java classes.
 
 ## Java version
 
-Since version 2 of this library, it requires Java 11 or higher. If you
-need a version compatible with Java 8, please use the last version 1
-release (1.0.3).
+| Ristretto | Mininum Java version |
+| --------- | -------------------- |
+| 1.x       | 1.8                  |
+| 2.x       | 11                   |
+| 3.x       | 17                   |
 
 ## Maven Coordinates
 

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@ limitations under the License.
     <project.build.outputTimestamp>${env.SOURCE_DATE_EPOCH}</project.build.outputTimestamp>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <java.minVersion>11</java.minVersion>
+    <java.minVersion>17</java.minVersion>
     <maven.javadoc.version>3.12.0</maven.javadoc.version>
     <dependencyCheck.version>12.1.6</dependencyCheck.version>
     <dependencyCheck.skip>false</dependencyCheck.skip>


### PR DESCRIPTION
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Readiness checklist
<!-- prettier-ignore-end -->

Please check the boxes below to confirm that you have followed the
required guidelines for contributions:

- [x] All commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification).
- [x] The title for this pull request is the same as the first commit's message and it follows the [conventional commits specification](https://www.conventionalcommits.org). See commit history for examples.
- [x] If this pull request includes code changes, they were all properly tested. Automated tests were also included where possible.
- [x] If applicable, this pull request includes the relevant documentation for this change.
- [x] If this pull request is related to an existing issue, you can use the same description below but in any case include a [link to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue) like `Fixes #ISSUE_NUMBER.` or `Closes #ISSUE_NUMBER.`.

<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Description

JDK 11 public support ended in September 2023. It seems reasonable to deprecate its support about 3 years later (i.e. around September 2026) so the next major release of ristretto (3.0.0) will not support JDK 11 anymore.

<!-- prettier-ignore-end -->
