### PR TITLE
ci(super-linter): stop Trivy from calling Maven Central

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -81,6 +81,41 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      #############################################################
+      # Give Trivy a local Maven repository to resolve POMs from  #
+      # (see TRIVY_OFFLINE_SCAN below). Only the runs that enable #
+      # Trivy's vulnerability scanner need it.                    #
+      #############################################################
+      - name: Restore Maven dependencies
+        if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+        # Same path and key as the Maven workflow, so this reuses the cache
+        # that workflow saves. Restore only: this workflow never saves a
+        # cache of its own.
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Move Maven dependencies where Trivy looks for them
+        if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          IFS=$'\n\t'
+          if [ ! -d .m2/repository ]; then
+            echo "No Maven cache restored: Trivy will report dependencies without their versions"
+            exit 0
+          fi
+          # super-linter is a Docker action, and the runner mounts
+          # "${RUNNER_TEMP}/_github_home" as the home directory inside the
+          # container, which is where Trivy looks for .m2/repository. Moving
+          # the dependencies out of the workspace also keeps Trivy from
+          # scanning the cached jars themselves.
+          mkdir -p "${RUNNER_TEMP}/_github_home/.m2"
+          mv .m2/repository "${RUNNER_TEMP}/_github_home/.m2/repository"
+
       ################################
       # Run Linter against code base #
       ################################
@@ -98,6 +133,17 @@ jobs:
           JAVA_FILE_NAME: google_checks.xml
           LINTER_RULES_PATH: .
           SAVE_SUPER_LINTER_SUMMARY: true
+          # Trivy's pom.xml analyzer resolves parent and BOM POMs from Maven
+          # Central even when the vuln scanner is off (Trivy 0.71.1, shipped
+          # with super-linter v8.7.0), and Maven Central answers "429 Too Many
+          # Requests" to Trivy's user agent from any IP, which aborts the whole
+          # run. Keep this unconditional rather than tying it to TRIVY_SCANNERS
+          # below: the runs that enable the vuln scanner get the same 429, so
+          # online resolution never succeeds there either. Trivy still resolves
+          # parent and BOM POMs from the local repository restored above, and a
+          # cache miss only costs coverage (a warning) instead of failing the
+          # run.
+          TRIVY_OFFLINE_SCAN: true
           TRIVY_SCANNERS: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'vuln,misconfig,secret' || 'misconfig,secret'}}
           VALIDATE_ALL_CODEBASE: true
           # Only lint commit messages when the run was triggered by a commit


### PR DESCRIPTION
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Readiness checklist
<!-- prettier-ignore-end -->

Please check the boxes below to confirm that you have followed the
required guidelines for contributions:

- [x] All commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification).
- [x] The title for this pull request is the same as the first commit's message and it follows the [conventional commits specification](https://www.conventionalcommits.org). See commit history for examples.
- [x] If this pull request includes code changes, they were all properly tested. Automated tests were also included where possible.
- [x] If applicable, this pull request includes the relevant documentation for this change.
- [x] If this pull request is related to an existing issue, you can use the same description below but in any case include a [link to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue) like `Fixes #ISSUE_NUMBER.` or `Closes #ISSUE_NUMBER.`.

<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Description
<!-- prettier-ignore-end -->
Maven Central answers "429 Too Many Requests" to Trivy's user agent from any IP, and Trivy 0.71.1 (shipped with super-linter v8.7.0) resolves parent and BOM POMs even when its vulnerability scanner is disabled, so every run aborted with a fatal error.

Set TRIVY_OFFLINE_SCAN to stop Trivy issuing those requests, and restore the Maven workflow's dependency cache into the home directory that the super-linter container sees, so Trivy still resolves the full dependency tree from disk on the runs that scan for vulnerabilities. A cache miss now costs coverage (a warning) instead of failing the run.
